### PR TITLE
Princípio da portabilidade

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@ São eles:
   <li><h3>FATOR MÚLTIPLO</h3><p>o governo deve fornecer estrutura para oferecer acesso de forma simples e facilitado para diferentes fatores de autenticação, que possam ser realizados por provedores de identidade distintos.</p></li>
   <li><h3>OPCIONAL</h3><p>A identificação digital deve ser opcional, desde que o cidadão tenha a identificação provida por outro meio.</p></li>
   <li><h3>INTEGRAÇÃO</h3><p>A identidade digital pode ser integrada aos demais registros</p></li>
+  <li><h3>PORTABILIDADE</h3>As aplicações e os serviços devem possibilitar que o cidadão carregue consigo os seus próprios dados pessoais, em dispositivo ou meio de armazenamento pessoal, podendo os mesmos serem verificados e assinados digitalmente por uma autoridade competente e essa certificação ser utilizada quando do uso da aplicação ou da prestação de serviço, quando for necessário, com a permissão de seu titular. Os bancos de dados pessoais podem existir apenas nas situações onde a natureza da aplicação ou da prestação do serviço for tal que seja tecnicamente impossível de operar sem o acesso em lote a múltiplos registros de dados pessoais, desde que a sua coleta e o seu uso sejam consentidos pelo cidadão.</li>
 </ul>
 
 


### PR DESCRIPTION
Proponho o princípio da portabilidade, para que o cidadão possa carregar consigo os seus próprios dados pessoais e, assim, ter maior controle e poder sobre a sua utilização. As situações em que bancos de dados pessoais podem existir deveriam ser excepcionais, limitadas e devidamente justificadas, e somente quando não for tecnicamente possível o próprio cidadão portar consigo os seus próprios dados.

A proposta visa limitar as situações em que exista o risco de vazamento em massa de dados pessoais, uma vez que reduz as situações em que seria permitida a existência de bancos de dados com informações pessoais.